### PR TITLE
Clear tempTrans Position After Updating oldTrans Coords

### DIFF
--- a/src/directive/angular-draggable.directive.ts
+++ b/src/directive/angular-draggable.directive.ts
@@ -105,6 +105,7 @@ export class AngularDraggableDirective implements OnInit {
       this.moving = false;
       this.oldTrans.x += this.tempTrans.x;
       this.oldTrans.y += this.tempTrans.y;
+      this.tempTrans.x = this.tempTrans.y = 0;
     }
   }
 


### PR DESCRIPTION
Make sure that we clear our tempTrans coordinates after updating the oldTrans cached coordinates so that simple clicks on the ngDraggable element do not compound the previous translation on the next drag (causing the element to jump on screen).