### PR TITLE
#6 Custom z-index: set z-index to 'auto' on putBack method

### DIFF
--- a/src/directive/angular-draggable.directive.ts
+++ b/src/directive/angular-draggable.directive.ts
@@ -109,7 +109,7 @@ export class AngularDraggableDirective implements OnInit {
 
   private putBack() {
     if (this.oldZIndex) {
-      this.renderer.setElementStyle(this.el.nativeElement, 'z-index', this.oldZIndex);
+      this.renderer.setElementStyle(this.el.nativeElement, 'z-index', 'auto');
     } else {
       this.el.nativeElement.style.removeProperty('z-index');
     }


### PR DESCRIPTION
setting z-index to 'auto', always display the last selected image/section on top of other. please validate the fix.