### PR TITLE
Prevent event default when dragging

### DIFF
--- a/lib/src/directive/angular-draggable.directive.ts
+++ b/lib/src/directive/angular-draggable.directive.ts
@@ -213,6 +213,7 @@ export class AngularDraggableDirective implements OnInit {
   onMouseMove(event: any) {
     if (this.moving && this.allowDrag) {
       this.moveTo(event.clientX, event.clientY);
+      return false;
     }
   }
 


### PR DESCRIPTION
When we mouse down and move quickly, then selection text occurs. This prevents event from default when we drag element.