### PR TITLE
Fixed using angular2-draggable with a scaled parent elment

### DIFF
--- a/lib/src/directive/angular-draggable.directive.ts
+++ b/lib/src/directive/angular-draggable.directive.ts
@@ -41,6 +41,9 @@ export class AngularDraggableDirective implements OnInit {
   /** Whether the element should use it's previous drag position on a new drag event. */
   @Input() trackPosition = true;
 
+  /** Input css scale transform of element so translations are correct */
+  @Input() scale = 1.00;
+
   @Input()
   set ngDraggable(setting: any) {
     if (setting !== undefined && setting !== null && setting !== '') {
@@ -73,8 +76,8 @@ export class AngularDraggableDirective implements OnInit {
     if (this.orignal) {
       let prevX = this.tempTrans.x;
       let prevY = this.tempTrans.y;
-      this.tempTrans.x = x - this.orignal.x;
-      this.tempTrans.y = y - this.orignal.y;
+      this.tempTrans.x = (x - this.orignal.x) / this.scale;
+      this.tempTrans.y = (y - this.orignal.y) / this.scale;
       this.transform();
 
       if (this.bounds) {
@@ -137,19 +140,19 @@ export class AngularDraggableDirective implements OnInit {
 
       if (this.inBounds) {
         if (!result.top) {
-          this.tempTrans.y -= elem.top - boundary.top;
+          this.tempTrans.y -= (elem.top - boundary.top) / this.scale;
         }
 
         if (!result.bottom) {
-          this.tempTrans.y -= elem.bottom - boundary.bottom;
+          this.tempTrans.y -= (elem.bottom - boundary.bottom) / this.scale;
         }
 
         if (!result.right) {
-          this.tempTrans.x -= elem.right - boundary.right;
+          this.tempTrans.x -= (elem.right - boundary.right) / this.scale;
         }
 
         if (!result.left) {
-          this.tempTrans.x -= elem.left - boundary.left;
+          this.tempTrans.x -= (elem.left - boundary.left) / this.scale;
         }
 
         this.transform();


### PR DESCRIPTION
This fixes the problem outlined here: https://github.com/xieziyu/angular2-draggable/issues/31. 

Note: I fixed for a parent with scaling not the element itself.

I work with the OP and it became necessary for us to get this working.

The issues occurs if there is a CSS transform scale on a parent of the element you want to drag. The errors are that the element is transformed by the unscaled distance, meaning the element effectively is transformed visibly by the distance * scale, meaning the cursor and the element become de-synced. It will also move out of bounds if bounds are set. 

I fixed these problems by dividing anything changing AngularDraggableDirective.tempTrans by the scale. I decided the best way to know the scale is to require the user to pass it in as an Input. You could probably use [window.getComputedStyle()](https://developer.mozilla.org/en/DOM:window.getComputedStyle) to work it out, but it seems overkill to do this.