### PR TITLE
add preventDefaultEvent flag to ngResizable mousedown

### DIFF
--- a/projects/angular2-draggable/src/lib/angular-resizable.directive.ts
+++ b/projects/angular2-draggable/src/lib/angular-resizable.directive.ts
@@ -102,6 +102,9 @@ export class AngularResizableDirective implements OnInit, OnChanges, OnDestroy, 
   /** The maximum height the resizable should be allowed to resize to. */
   @Input() rzMaxHeight: number = null;
 
+  /** Whether to prevent default event */
+  @Input() preventDefaultEvent = false;
+
   /** emitted when start resizing */
   @Output() rzStart = new EventEmitter<IResizeEvent>();
 
@@ -284,9 +287,11 @@ export class AngularResizableDirective implements OnInit, OnChanges, OnDestroy, 
       return;
     }
 
-    // prevent default events
-    event.stopPropagation();
-    event.preventDefault();
+    if (this.preventDefaultEvent) {
+      // prevent default events
+      event.stopPropagation();
+      event.preventDefault();
+    }
 
     if (!this._handleResizing) {
       this._origMousePos = Position.fromEvent(event);

--- a/projects/angular2-draggable/src/lib/angular-resizable.directive.ts
+++ b/projects/angular2-draggable/src/lib/angular-resizable.directive.ts
@@ -103,7 +103,7 @@ export class AngularResizableDirective implements OnInit, OnChanges, OnDestroy, 
   @Input() rzMaxHeight: number = null;
 
   /** Whether to prevent default event */
-  @Input() preventDefaultEvent = false;
+  @Input() preventDefaultEvent = true;
 
   /** emitted when start resizing */
   @Output() rzStart = new EventEmitter<IResizeEvent>();


### PR DESCRIPTION
We use https://github.com/zzarcon/default-passive-events in our project, which makes `mousedown` a passive event, so when using Resizable directive, it produced 
```
Unable to preventDefault inside passive event listener invocation.
```