### PR TITLE
Fixed flickering of the component on initial drag while scale is applied to the parent

### DIFF
--- a/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
+++ b/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
@@ -148,7 +148,7 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
       }
     }
 
-    if (changes['scale'] && !changes['scale'].isFirstChange()) {
+    if (this.isDragged && changes['scale'] && !changes['scale'].isFirstChange()) {
       this.oldTrans.x = this.currTrans.x * this.scale;
       this.oldTrans.y = this.currTrans.y * this.scale;
     }


### PR DESCRIPTION
The issue is - when some scale (>1) is applied to the parent container and the child container is clicked for the first time, it changes its position. To fix the issue, I just added a check in the onChanges method while checking for scale related changes.