### PR TITLE
Fixed draggable position bouncing when draggable is scaled and position is set

### DIFF
--- a/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
+++ b/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
@@ -31,11 +31,6 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
    */
   private _helperBlock: HelperBlock = null;
 
-  /**
-   * Flag to indicate whether the element is dragged once after being initialised
-   */
-  private isDragged = false;
-
   @Output() started = new EventEmitter<any>();
   @Output() stopped = new EventEmitter<any>();
   @Output() edge = new EventEmitter<any>();
@@ -148,11 +143,6 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
         this.needTransform = true;
       }
     }
-
-    if (this.isDragged && changes['scale'] && !changes['scale'].isFirstChange()) {
-      this.oldTrans.x = this.currTrans.x * this.scale;
-      this.oldTrans.y = this.currTrans.y * this.scale;
-    }
   }
 
   ngAfterViewInit() {
@@ -181,6 +171,7 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
     if (this.orignal) {
       p.subtract(this.orignal);
       this.tempTrans.set(p);
+      this.tempTrans.divide(this.scale);
       this.transform();
 
       if (this.bounds) {
@@ -192,16 +183,6 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
   }
 
   private transform() {
-    // done to prevent the element from bouncing off when
-    // the parent element is scaled and element is dragged for first time
-    if (this.tempTrans.x !== 0 || this.tempTrans.y !== 0) {
-      if (this.isDragged === false) {
-        this.oldTrans.x = this.currTrans.x * this.scale;
-        this.oldTrans.y = this.currTrans.y * this.scale;
-      }
-      this.isDragged = true;
-    }
-
     let translateX = this.tempTrans.x + this.oldTrans.x;
     let translateY = this.tempTrans.y + this.oldTrans.y;
 
@@ -217,11 +198,6 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
     if (this.gridSize > 1) {
       translateX = Math.round(translateX / this.gridSize) * this.gridSize;
       translateY = Math.round(translateY / this.gridSize) * this.gridSize;
-    }
-
-    if (this.scale && this.scale !== 0 && this.isDragged) {
-      translateX = translateX / this.scale;
-      translateY = translateY / this.scale;
     }
 
     let value = `translate(${translateX}px, ${translateY}px)`;
@@ -289,19 +265,19 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
 
       if (this.inBounds) {
         if (!result.top) {
-          this.tempTrans.y -= elem.top - boundary.top;
+          this.tempTrans.y -= (elem.top - boundary.top) / this.scale;
         }
 
         if (!result.bottom) {
-          this.tempTrans.y -= elem.bottom - boundary.bottom;
+          this.tempTrans.y -= (elem.bottom - boundary.bottom) / this.scale;
         }
 
         if (!result.right) {
-          this.tempTrans.x -= elem.right - boundary.right;
+          this.tempTrans.x -= (elem.right - boundary.right) / this.scale;
         }
 
         if (!result.left) {
-          this.tempTrans.x -= elem.left - boundary.left;
+          this.tempTrans.x -= (elem.left - boundary.left) / this.scale;
         }
 
         this.transform();

--- a/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
+++ b/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
@@ -192,6 +192,16 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
   }
 
   private transform() {
+    // done to prevent the element from bouncing off when
+    // the parent element is scaled and element is dragged for first time
+    if (this.tempTrans.x !== 0 || this.tempTrans.y !== 0) {
+      if (this.isDragged === false) {
+        this.oldTrans.x = this.currTrans.x * this.scale;
+        this.oldTrans.y = this.currTrans.y * this.scale;
+      }
+      this.isDragged = true;
+    }
+
     let translateX = this.tempTrans.x + this.oldTrans.x;
     let translateY = this.tempTrans.y + this.oldTrans.y;
 
@@ -207,16 +217,6 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
     if (this.gridSize > 1) {
       translateX = Math.round(translateX / this.gridSize) * this.gridSize;
       translateY = Math.round(translateY / this.gridSize) * this.gridSize;
-    }
-
-    // done to prevent the element from bouncing off when
-    // the parent element is scaled and element is dragged for first time
-    if (this.tempTrans.x !== 0 || this.tempTrans.y !== 0) {
-      if (this.isDragged === false) {
-        this.oldTrans.x = this.currTrans.x * this.scale;
-        this.oldTrans.y = this.currTrans.y * this.scale;
-      }
-      this.isDragged = true;
     }
 
     if (this.scale && this.scale !== 0 && this.isDragged) {

--- a/projects/angular2-draggable/src/lib/models/position.ts
+++ b/projects/angular2-draggable/src/lib/models/position.ts
@@ -68,6 +68,16 @@ export class Position implements IPosition {
     return this;
   }
 
+  multiply(n: number) {
+    this.x *= n;
+    this.y *= n;
+  }
+
+  divide(n: number) {
+    this.x /= n;
+    this.y /= n;
+  }
+
   reset() {
     this.x = 0;
     this.y = 0;


### PR DESCRIPTION
Fixed #149 
As i fixed this bug for the 1st time by moving the bouncing check up (see my 1st commit) I just didn't really like how the scaling code was implemented (needed isDragged, and bouncing fix), so i mostly rewrote how its calculated. Now it just divides moved pixels with scale, so if we moved the draggable by 1px and the scale is 0.5 then it will set that we moved 1 / 0.5 = 2px, the only problem is that broke the bounds and i had to divide the moved pixels with the scale, but i would suggest to just set the draggable position to bounding box side, not constantly removing the difference between the two.

As I was testing my fix i came across another bug that this PR fixes. Scale and gridSize doesn't work together.

Previously, current master:
![previously](https://i.imgur.com/secabOz.gif)
Now, pr:
![fixed](https://i.imgur.com/HJ8QnXE.gif)

As this isn't so small of a fix and I am afraid that i may have broken something (I tried to test as much as possible, dynamically changing scale, checking if draggable position doesn't change), I would like to ask the scale implementer (@rathodsanjay) to check if I didn't break anything for him.