### PR TITLE
fix translate in draggable.directive

### DIFF
--- a/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
+++ b/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
@@ -224,7 +224,7 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
       translateY = translateY / this.scale;
     }
 
-    let value = `translate(${translateX}px, ${translateY}px)`;
+    let value = `translate(${ Math.round(translateX) }px, ${ Math.round(translateY) }px)`;
 
     this.renderer.setStyle(this.el.nativeElement, 'transform', value);
     this.renderer.setStyle(this.el.nativeElement, '-webkit-transform', value);


### PR DESCRIPTION
The problem is due to the fact that when the extreme state is reached in the parent block, then transform: translate() gets fractional values, such as translate(123.458 px, ...) for example. In this regard, there will be a similar situation. This fix is the fastest that can be done.
![Запись_экрана_2019-03-21_в_11 47 29](https://user-images.githubusercontent.com/26469604/54758491-50727c00-4bfd-11e9-9047-3a28df52141f.gif)

