### PR TITLE
fix issue with dragging window inside iframe by deleting mouseleave e…

### DIFF
--- a/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
+++ b/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
@@ -265,7 +265,6 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
     this.draggingSub = fromEvent(document, 'mousemove', { passive: false }).subscribe(event => this.onMouseMove(event as MouseEvent));
     this.draggingSub.add(fromEvent(document, 'touchmove', { passive: false }).subscribe(event => this.onMouseMove(event as TouchEvent)));
     this.draggingSub.add(fromEvent(document, 'mouseup', { passive: false }).subscribe(() => this.putBack()));
-    this.draggingSub.add(fromEvent(document, 'mouseleave', { passive: false }).subscribe(() => this.putBack()));
     this.draggingSub.add(fromEvent(document, 'touchend', { passive: false }).subscribe(() => this.putBack()));
     this.draggingSub.add(fromEvent(document, 'touchcancel', { passive: false }).subscribe(() => this.putBack()));
 

--- a/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
+++ b/projects/angular2-draggable/src/lib/angular-draggable.directive.ts
@@ -265,9 +265,13 @@ export class AngularDraggableDirective implements OnInit, OnDestroy, OnChanges, 
     this.draggingSub = fromEvent(document, 'mousemove', { passive: false }).subscribe(event => this.onMouseMove(event as MouseEvent));
     this.draggingSub.add(fromEvent(document, 'touchmove', { passive: false }).subscribe(event => this.onMouseMove(event as TouchEvent)));
     this.draggingSub.add(fromEvent(document, 'mouseup', { passive: false }).subscribe(() => this.putBack()));
+    // checking if browser is IE or Edge - https://github.com/xieziyu/angular2-draggable/issues/153
+    let isIEOrEdge = /msie\s|trident\//i.test(window.navigator.userAgent);
+    if (!isIEOrEdge) {
+      this.draggingSub.add(fromEvent(document, 'mouseleave', {passive: false}).subscribe(() => this.putBack()));
+    }
     this.draggingSub.add(fromEvent(document, 'touchend', { passive: false }).subscribe(() => this.putBack()));
     this.draggingSub.add(fromEvent(document, 'touchcancel', { passive: false }).subscribe(() => this.putBack()));
-
   }
 
   private unsubscribeEvents() {


### PR DESCRIPTION
…vent. On IE mouseleave event is firing all the inside iframe, so it was not possible to moving window anyware. I think deleting that doesn't break anything, we need to only catch mouseup event.