### PR TITLE
Fix: Element move when resizing using the NW and NE handles and aspect ratio is enabled

### DIFF
--- a/projects/angular2-draggable/src/lib/angular-resizable.directive.ts
+++ b/projects/angular2-draggable/src/lib/angular-resizable.directive.ts
@@ -436,9 +436,21 @@ export class AngularResizableDirective implements OnInit, OnChanges, OnDestroy, 
   private adjustByRatio() {
     if (this._aspectRatio) {
       if (this._direction.e || this._direction.w) {
-        this._currSize.height = this._currSize.width / this._aspectRatio;
+        const newHeight = this._currSize.width / this._aspectRatio;
+
+        if (this._direction.n) {
+          this._currPos.y += this._currSize.height - newHeight;
+        }
+
+        this._currSize.height = newHeight;
       } else {
-        this._currSize.width = this._aspectRatio * this._currSize.height;
+        const newWidth = this._aspectRatio * this._currSize.height;
+
+        if (this._direction.n) {
+          this._currPos.x += this._currSize.width - newWidth;
+        }
+
+        this._currSize.width = newWidth;
       }
     }
   }


### PR DESCRIPTION
Fixed #155 

**Before:**

![screen-capture-_1_](https://user-images.githubusercontent.com/14935048/56332882-f7cada80-61cc-11e9-805b-1cb37950d1ee.gif)


**After:**

![screen-capture](https://user-images.githubusercontent.com/14935048/56332912-103af500-61cd-11e9-9614-f864229d210d.gif)

