### PR TITLE
add the resize direction to event

### DIFF
--- a/projects/angular2-draggable/src/lib/angular-resizable.directive.ts
+++ b/projects/angular2-draggable/src/lib/angular-resizable.directive.ts
@@ -378,7 +378,8 @@ export class AngularResizableDirective implements OnInit, OnChanges, OnDestroy, 
       position: {
         top: this._currPos.y,
         left: this._currPos.x
-      }
+      },
+      direction: this._direction
     };
   }
 

--- a/projects/angular2-draggable/src/lib/models/resize-event.ts
+++ b/projects/angular2-draggable/src/lib/models/resize-event.ts
@@ -8,4 +8,10 @@ export interface IResizeEvent {
     top: number;
     left: number;
   };
+  direction: {
+    n: boolean;
+    s: boolean;
+    w: boolean;
+    e: boolean;
+  };
 }


### PR DESCRIPTION
Direction can be helpful in many ways. It is computed before the event is triggered and cleared at the end.